### PR TITLE
Add Vercel deployment config

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,4 @@
+from app import app
+
+# Vercel looks for the 'app' variable to start the Flask application.
+# When deploying, Vercel will expose this as a serverless function.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [{
+    "src": "api/index.py",
+    "use": "@vercel/python"
+  }],
+  "routes": [{
+    "src": "/(.*)",
+    "dest": "api/index.py"
+  }]
+}


### PR DESCRIPTION
## Summary
- add Vercel deployment files so the Flask app runs on `/`

## Testing
- `pytest -q` *(fails: pytest not installed)*