### PR TITLE
Switch to GPT-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a simple Flask web application that provides a colorful chat interface f
 - "Speak" button to send a message
 - "Stop" button (currently does nothing but can be extended)
 - Colorful, kid-friendly UI
-- Uses OpenAI's API to generate responses (requires `OPENAI_API_KEY` environment variable)
+- Uses OpenAI's `gpt-4` model to generate responses (requires `OPENAI_API_KEY` environment variable)
 
 ## Setup
 

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ def chat():
         return jsonify({'error': 'No message provided'}), 400
     try:
         response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+            model="gpt-4",
             messages=[{'role': 'system', 'content': 'You are a friendly talking cat named Whiskers who loves chatting with children age 6-8.'},
                      {'role': 'user', 'content': user_message}],
             temperature=0.7,


### PR DESCRIPTION
## Summary
- use `gpt-4` for responses
- document GPT-4 usage in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*