### PR TITLE
Use OpenAI TTS instead of browser speech synthesis

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -57,25 +57,10 @@
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
     const isAndroid = /Android/i.test(navigator.userAgent);
 
-    // Initialize speech synthesis
-    const synth = window.speechSynthesis;
-    let currentUtterance = null;
+    // Audio playback control
+    let currentAudio = null;
     let isSpeaking = false;
     let isConversationActive = false;
-    let voicesReady = false;
-
-    function loadVoices() {
-        if (synth.getVoices().length > 0) {
-            voicesReady = true;
-            speechSynthesis.removeEventListener('voiceschanged', loadVoices);
-        }
-    }
-
-    // Attempt to load voices immediately and listen for changes
-    loadVoices();
-    if (!voicesReady) {
-        speechSynthesis.addEventListener('voiceschanged', loadVoices);
-    }
 
     // Check if browser supports speech recognition
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -157,13 +142,6 @@
         const silentAudio = new Audio("data:audio/mp3;base64,//uQxAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAACAAACcQCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgAAAAA=");
         silentAudio.play().catch(e => console.log("Silent audio play error:", e));
         
-        // Try to initialize speech synthesis
-        if ('speechSynthesis' in window) {
-            // Create a short utterance and speak it silently
-            const speech = new SpeechSynthesisUtterance('');
-            speech.volume = 0;
-            window.speechSynthesis.speak(speech);
-        }
         
         audioInitialized = true;
         console.log("Audio initialization complete!");
@@ -247,156 +225,15 @@
     }
 
     function speak(text) {
-        // First make sure audio is initialized (especially important for iOS)
-        if (!audioInitialized && (isIOS || isAndroid)) {
-            initializeAudio();
-        }
-
-        // Filter out emojis and symbols for speech
-        const cleanText = text.replace(/[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F900}-\u{1F9FF}\u{1F1E0}-\u{1F1FF}\u{1F200}-\u{1F2FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{1FAB0}-\u{1FABF}\u{1FAC0}-\u{1FAFF}\u{1FAD0}-\u{1FAFF}\u{1FAE0}-\u{1FAFF}\u{1FAF0}-\u{1FAFF}\u{1FB00}-\u{1FBFF}\u{1FC00}-\u{1FCFF}\u{1FD00}-\u{1FDFF}\u{1FE00}-\u{1FEFF}\u{1FF00}-\u{1FFFF}\u{2000}-\u{206F}\u{2070}-\u{209F}\u{20A0}-\u{20CF}\u{20D0}-\u{20FF}\u{2100}-\u{214F}\u{2150}-\u{218F}\u{2190}-\u{21FF}\u{2200}-\u{22FF}\u{2300}-\u{23FF}\u{2400}-\u{243F}\u{2440}-\u{245F}\u{2460}-\u{24FF}\u{2500}-\u{257F}\u{2580}-\u{259F}\u{25A0}-\u{25FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{2800}-\u{28FF}\u{2900}-\u{297F}\u{2980}-\u{29FF}\u{2A00}-\u{2AFF}\u{2B00}-\u{2BFF}\u{2C00}-\u{2C5F}\u{2C60}-\u{2C7F}\u{2C80}-\u{2CFF}\u{2D00}-\u{2D2F}\u{2D30}-\u{2D7F}\u{2D80}-\u{2DDF}\u{2DE0}-\u{2DFF}\u{2E00}-\u{2E7F}\u{2E80}-\u{2EFF}\u{2F00}-\u{2FDF}\u{2FF0}-\u{2FFF}\u{3000}-\u{303F}\u{3040}-\u{309F}\u{30A0}-\u{30FF}\u{3100}-\u{312F}\u{3130}-\u{318F}\u{3190}-\u{319F}\u{31A0}-\u{31BF}\u{31C0}-\u{31EF}\u{31F0}-\u{31FF}\u{3200}-\u{32FF}\u{3300}-\u{33FF}\u{3400}-\u{4DBF}\u{4DC0}-\u{4DFF}\u{4E00}-\u{9FFF}\u{A000}-\u{A48F}\u{A490}-\u{A4CF}\u{A4D0}-\u{A4FF}\u{A500}-\u{A63F}\u{A640}-\u{A69F}\u{A6A0}-\u{A6FF}\u{A700}-\u{A71F}\u{A720}-\u{A7FF}\u{A800}-\u{A82F}\u{A830}-\u{A83F}\u{A840}-\u{A87F}\u{A880}-\u{A8DF}\u{A8E0}-\u{A8FF}\u{A900}-\u{A92F}\u{A930}-\u{A95F}\u{A960}-\u{A97F}\u{A980}-\u{A9DF}\u{A9E0}-\u{A9FF}\u{AA00}-\u{AA5F}\u{AA60}-\u{AA7F}\u{AA80}-\u{AADF}\u{AAE0}-\u{AAFF}\u{AB00}-\u{AB2F}\u{AB30}-\u{AB6F}\u{AB70}-\u{ABBF}\u{ABC0}-\u{ABFF}\u{AC00}-\u{D7AF}\u{D7B0}-\u{D7FF}\u{D800}-\u{DB7F}\u{DB80}-\u{DBFF}\u{DC00}-\u{DFFF}\u{E000}-\u{F8FF}\u{F900}-\u{FAFF}\u{FB00}-\u{FB4F}\u{FB50}-\u{FDFF}\u{FE00}-\u{FE0F}\u{FE10}-\u{FE1F}\u{FE20}-\u{FE2F}\u{FE30}-\u{FE4F}\u{FE50}-\u{FE6F}\u{FE70}-\u{FEFF}\u{FF00}-\u{FFEF}\u{FFF0}-\u{FFFF}]/gu, '');
-
-        if (!voicesReady && synth.getVoices().length === 0) {
-            speechSynthesis.addEventListener("voiceschanged", () => speak(text), { once: true });
-            synth.getVoices();
-            return;
-        }
-        // Cancel any ongoing speech
-        if (currentUtterance) {
-            synth.cancel();
-        }
-
-        const utterance = new SpeechSynthesisUtterance(cleanText);
-        utterance.lang = 'en-US';
-
-        // Configure voice settings for a more natural sound
-        utterance.rate = 0.95;
-        utterance.pitch = 1.0;
-        utterance.volume = 1.0;
-
-        // Special handling for iOS voices
-        let voiceList = synth.getVoices();
-        
-        // For iOS devices, wait a moment before trying to get voices if the list is empty
-        if (isIOS && (!voiceList || voiceList.length === 0)) {
-            console.log("No voices available yet, waiting for voices to load...");
-            setTimeout(() => {
-                voiceList = synth.getVoices();
-                selectVoiceAndSpeak();
-            }, 1000);
-        } else {
-            selectVoiceAndSpeak();
-        }
-
-        function selectVoiceAndSpeak() {
-            // Try to select a natural-sounding voice if available
-            const voices = synth.getVoices();
-            console.log("Available voices:", voices.length);
-            
-            let selectedVoice = null;
-            
-            // First try iOS-specific voices
-            if (isIOS) {
-                selectedVoice = voices.find(voice =>
-                    voice.name.includes('Samantha') ||
-                    voice.name.includes('Karen') ||
-                    voice.name.includes('Moira') ||
-                    voice.name.includes('Tessa')
-                );
-            }
-            
-            // If no iOS-specific voice found, try common voices
-            if (!selectedVoice) {
-                selectedVoice = voices.find(voice =>
-                    voice.name.includes('Google US English') ||
-                    voice.name.includes('Google UK English Female') ||
-                    voice.name.includes('Microsoft Aria') ||
-                    voice.name.includes('Microsoft Jenny') ||
-                    voice.name.includes('Samantha')
-                );
-            }
-            
-            // Default to any female voice as fallback
-            if (!selectedVoice) {
-                selectedVoice = voices.find(voice =>
-                    voice.name.toLowerCase().includes('female') ||
-                    voice.name.includes('Samantha')
-                );
-            }
-            
-            if (selectedVoice) {
-                utterance.voice = selectedVoice;
-                console.log("Selected voice:", selectedVoice.name);
-            } else if (voices.length > 0) {
-                // Just use the first available voice if nothing else works
-                utterance.voice = voices[0];
-                console.log("Using default voice:", voices[0].name);
-            }
-
-            // Pause recognition while speaking
-            if (isListening) {
-                recognition.stop();
-            }
-            isSpeaking = true;
-            isConversationActive = true;
-            updateStopButton();
-
-            utterance.onstart = () => {
-                micBtn.classList.add('speaking');
-            };
-
-            utterance.onend = () => {
-                isSpeaking = false;
-                micBtn.classList.remove('speaking');
-                // Resume recognition if we're still supposed to be listening
-                if (isListening) {
-                    try {
-                        recognition.start();
-                    } catch (error) {
-                        console.error('Error restarting speech recognition:', error);
-                    }
-                } else {
-                    isConversationActive = false;
-                    updateStopButton();
-                }
-            };
-
-            // Handle iOS-specific issues with onend not firing
-            if (isIOS) {
-                // Set a timeout based on text length to handle cases where onend doesn't fire
-                const textLength = cleanText.length;
-                const timeEstimate = Math.max(2000, textLength * 90); // ~90ms per character, minimum 2 seconds
-                
-                setTimeout(() => {
-                    if (isSpeaking) {
-                        console.log("iOS speech timeout - ending manually");
-                        isSpeaking = false;
-                        micBtn.classList.remove('speaking');
-                        
-                        // Resume recognition if needed
-                        if (isListening) {
-                            try {
-                                recognition.start();
-                            } catch (error) {
-                                console.error('Error restarting speech recognition:', error);
-                            }
-                        } else {
-                            isConversationActive = false;
-                            updateStopButton();
-                        }
-                    }
-                }, timeEstimate);
-            }
-
-            currentUtterance = utterance;
-            try {
-                synth.speak(utterance);
-                console.log("Speaking now:", cleanText.substring(0, 50) + "...");
-            } catch (error) {
-                console.error("Speech synthesis error:", error);
-                isSpeaking = false;
-                micBtn.classList.remove('speaking');
-            }
-        }
+        if (!text) return;
+        fetch("/tts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text })
+        })
+        .then(r => { if (!r.ok) throw new Error("TTS request failed"); return r.blob(); })
+        .then(b => { const url = URL.createObjectURL(b); const a = new Audio(url); currentAudio = a; a.play().catch(e => console.error("Audio play error:", e)); })
+        .catch(e => console.error("TTS error:", e));
     }
 
     function addMessage(text, isUser = false) {
@@ -475,8 +312,9 @@
         }
         
         // Stop any ongoing speech
-        if (currentUtterance) {
-            synth.cancel();
+        if (currentAudio) {
+            currentAudio.pause();
+            currentAudio.currentTime = 0;
         }
         
         // Reset states
@@ -491,8 +329,9 @@
     clearBtn.addEventListener('click', () => {
         chatbox.innerHTML = '';
         // Stop any ongoing speech
-        if (currentUtterance) {
-            synth.cancel();
+        if (currentAudio) {
+            currentAudio.pause();
+            currentAudio.currentTime = 0;
         }
         // Reset states
         isSpeaking = false;
@@ -508,8 +347,9 @@
                 recognition.stop();
             }
             // Stop any ongoing speech
-            if (currentUtterance) {
-                synth.cancel();
+            if (currentAudio) {
+                currentAudio.pause();
+                currentAudio.currentTime = 0;
             }
             // Reset states
             isSpeaking = false;
@@ -518,13 +358,6 @@
         }
     });
 
-    // Initialize voices when they become available
-    if (speechSynthesis.onvoiceschanged !== undefined) {
-        speechSynthesis.onvoiceschanged = () => {
-            // Voices are now available
-            console.log('Voices loaded:', speechSynthesis.getVoices().length);
-        };
-    }
     </script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,3 +4,8 @@ def test_index():
     tester = app.test_client()
     response = tester.get('/')
     assert response.status_code == 200
+
+def test_tts_no_text():
+    tester = app.test_client()
+    response = tester.post('/tts', json={})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add `/tts` endpoint using OpenAI's text-to-speech API
- update frontend `speak()` to fetch audio from `/tts`
- remove browser speech synthesis logic
- add basic test for new TTS route

## Testing
- `pytest -q` *(fails: `pytest` not found)*