### PR TITLE
Add text labels to call controls

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -162,13 +162,13 @@ textarea {
     border: none;
     font-size: 24px;
     cursor: pointer;
-    padding: 0;
-    width: 50px;
+    padding: 0 15px;
     height: 50px;
-    border-radius: 50%;
+    border-radius: 25px;
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 5px;
     transition: background-color 0.3s;
 }
 
@@ -190,15 +190,15 @@ textarea {
     background: #ff3b30;
     color: white;
     border: none;
-    width: 50px;
     height: 50px;
-    border-radius: 50%;
+    border-radius: 25px;
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 5px;
     font-size: 24px;
     cursor: pointer;
-    padding: 0;
+    padding: 0 15px;
     transition: background-color 0.3s;
 }
 
@@ -341,4 +341,8 @@ button:disabled {
 
 .hidden {
     display: none;
+}
+
+.button-label {
+    font-size: 16px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,11 +50,13 @@
                     <svg viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M22 16.92v3a2.09 2.09 0 01-2.26 2.09A19.72 19.72 0 012.28 5.35 2.09 2.09 0 014.37 3h3a1 1 0 011 .75l1.09 4.41a1 1 0 01-.27 1L6.91 11.09a16 16 0 006 6l2.2-2.2a1 1 0 011-.27l4.38 1.09a1 1 0 01.75 1z"/>
                     </svg>
+                    <span class="button-label">Call</span>
                 </button>
                 <button id="end-call" class="end-call-button" title="End Call">
                     <svg viewBox="0 0 24 24" aria-hidden="true" class="end-icon">
                         <path d="M22 16.92v3a2.09 2.09 0 01-2.26 2.09A19.72 19.72 0 012.28 5.35 2.09 2.09 0 014.37 3h3a1 1 0 011 .75l1.09 4.41a1 1 0 01-.27 1L6.91 11.09a16 16 0 006 6l2.2-2.2a1 1 0 011-.27l4.38 1.09a1 1 0 01.75 1z"/>
                     </svg>
+                    <span class="button-label">End</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add `Call` and `End` text labels to call control buttons
- adjust button styling for text

## Testing
- `pytest -q` *(fails: command not found)*