### PR TITLE
Add auto-stop after 30 seconds of silence

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,4 +11,4 @@ if not OPENAI_API_KEY:
 
 # Flask Configuration
 DEBUG = os.getenv("FLASK_DEBUG", "True").lower() == "true"
-SECRET_KEY = os.getenv("SECRET_KEY", "dev") 
+SECRET_KEY = os.getenv("SECRET_KEY", "dev")

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,16 @@
     let isListening = false;
     let finalTranscript = '';
     let interimTranscript = '';
+    let silenceTimer = null;
+
+    function resetSilenceTimer() {
+        clearTimeout(silenceTimer);
+        silenceTimer = setTimeout(() => {
+            if (isListening) {
+                endCall();
+            }
+        }, 30000); // 30 seconds
+    }
 
     // Function to show the animation
     function showAnimation(animationType) {
@@ -176,6 +186,7 @@
             micBtn.classList.add('listening');
             isListening = true;
             showAnimation('listening');
+            resetSilenceTimer();
 
         };
 
@@ -183,6 +194,7 @@
             // Don't process results while Hailey is speaking
             if (isSpeaking) return;
 
+            resetSilenceTimer();
             interimTranscript = '';
             for (let i = event.resultIndex; i < event.results.length; i++) {
                 const transcript = event.results[i][0].transcript;
@@ -200,6 +212,7 @@
             if (isSpeaking) {
                 return; // wait for TTS to finish
             }
+            clearTimeout(silenceTimer);
             showAnimation('');
             if (isListening) {
                 try {
@@ -317,6 +330,7 @@
             isListening = false;
             recognition.stop();
         }
+        clearTimeout(silenceTimer);
         isSpeaking = false;
         micBtn.classList.remove('speaking', 'listening');
         showAnimation('');


### PR DESCRIPTION
## Summary
- add 30s silence timeout to end conversations
- clean up config file line ending

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*