### PR TITLE
Add speech autocorrect using GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ python app.py
 - Clear chat functionality
 - Character limit on messages
 - Enter key support for sending messages
+- Speech recognition auto-corrects transcripts
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -56,5 +56,36 @@ def tts():
         print(f"TTS Error: {str(e)}")
         return jsonify({'error': str(e)}), 500
 
+
+@app.route('/correct', methods=['POST'])
+def correct():
+    """Use GPT to auto-correct transcribed speech text."""
+    text = request.json.get('text', '')
+    if not text:
+        return jsonify({'error': 'No text provided'}), 400
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4",
+            messages=[
+                {
+                    'role': 'system',
+                    'content': (
+                        'You are a helpful assistant that fixes mistakes in '
+                        'short phrases transcribed from speech recognition. '
+                        'Return only the corrected text.'
+                    )
+                },
+                {'role': 'user', 'content': text}
+            ],
+            temperature=0,
+            max_tokens=60,
+        )
+        corrected = response.choices[0].message.content.strip()
+        return jsonify({'corrected': corrected})
+    except Exception as e:
+        print(f"Correction Error: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
 if __name__ == '__main__':
     app.run(debug=DEBUG)

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,8 +201,10 @@
                 const transcript = event.results[i][0].transcript;
                 if (event.results[i].isFinal) {
                     finalTranscript = transcript;
-                    // Automatically send the message when final transcript is received
-                    sendMessage(finalTranscript);
+                    // Automatically correct and send the message when final transcript is received
+                    correctText(finalTranscript).then(corrected => {
+                        sendMessage(corrected);
+                    });
                 } else {
                     interimTranscript += transcript;
                 }
@@ -294,6 +296,21 @@
 
     function setLoading(isLoading) {
         loading.style.display = isLoading ? 'block' : 'none';
+    }
+
+    async function correctText(text) {
+        try {
+            const response = await fetch('/correct', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text })
+            });
+            const data = await response.json();
+            return data.corrected || text;
+        } catch (error) {
+            console.error('Error correcting text:', error);
+            return text;
+        }
     }
 
     async function sendMessage(text) {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,8 @@ def test_tts_no_text():
     tester = app.test_client()
     response = tester.post('/tts', json={})
     assert response.status_code == 400
+
+def test_correct_no_text():
+    tester = app.test_client()
+    response = tester.post('/correct', json={})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- implement `/correct` route in Flask app to autocorrect transcribed speech
- call the new endpoint from the frontend to fix transcripts
- add missing test for `/correct` endpoint
- document speech autocorrect feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*